### PR TITLE
Create carbon-credits-mock.clar

### DIFF
--- a/contracts/carbon-credits-mock.clar
+++ b/contracts/carbon-credits-mock.clar
@@ -1,0 +1,20 @@
+;; contracts/carbon-credits-mock.clar
+
+(impl-trait .carbon-credits-trait)
+
+;; Always fails transfers
+(define-public (transfer-carbon-credit (token-id uint) (recipient principal))
+  (err u999))
+
+;; Mock mint function for testing
+(define-public (mint-mock-token (owner principal))
+  (begin
+    (map-set token-owners u1 owner)
+    (ok true)))
+
+;; Mock owner lookup
+(define-read-only (get-token-owner (token-id uint))
+  (map-get? token-owners token-id))
+
+;; Storage for mock
+(define-map token-owners uint principal)


### PR DESCRIPTION
Mock created for testing the purchase edge case removing listing even if NFT transfer fails.