### PR TITLE
Update CarbonMarketplace.clar

### DIFF
--- a/contracts/CarbonMarketplace.clar
+++ b/contracts/CarbonMarketplace.clar
@@ -1,17 +1,64 @@
-(define-public (buy-carbon-credit (token-id uint))
-  (let ((listing (map-get? .CarbonListing listings token-id)))
+ (define-non-fungible-token carbon-credit uint)
+
+(define-map token-owners uint principal)
+(define-map token-metadata uint
+  {
+    project: (string-utf8 50),
+    location: (string-utf8 50),
+    metric-ton: uint,
+    retired: bool
+  }
+)
+
+(define-data-var next-token-id uint u1)
+
+(define-public (mint (to principal) (project (string-utf8 50)) (location (string-utf8 50)) (metric-ton uint))
+  (let ((token-id (var-get next-token-id)))
     (begin
-      (asserts! (is-some listing) (err u300))
-      (let ((seller (unwrap! listing (err u301)).seller)
-            (price (unwrap! listing (err u302)).price))
+      (asserts! (<= (len project) u50) (err u200))
+      (asserts! (<= (len location) u50) (err u201))
+      (asserts! (> metric-ton u0) (err u202))
 
-        ;; Transfer STX to seller
-        (try! (stx-transfer? price tx-sender seller))
+      (asserts! (map-insert token-owners token-id to) (err u100))
+      (asserts! (map-insert token-metadata token-id {project: project, location: location, metric-ton: metric-ton, retired: false}) (err u101))
+      (var-set next-token-id (+ token-id u1))
+      (ok token-id)
+    )
+  )
+)
 
-        ;; Transfer NFT ownership in CarbonCredits contract
-        (try! (contract-call? .CarbonCredits transfer-carbon-credit token-id tx-sender))
+(define-public (transfer (token-id uint) (recipient principal))
+  (let ((owner (map-get? token-owners token-id)))
+    (begin
+      (asserts! (is-some owner) (err u102))
+      (asserts! (is-eq (unwrap! owner (err u103)) tx-sender) (err u104))
+      (asserts! (map-set token-owners token-id recipient) (err u105))
+      (ok token-id)
+    )
+  )
+)
 
-        ;; Remove from sale
-        (map-delete .CarbonListing listings token-id)
+(define-public (retire-carbon-credit (token-id uint))
+  (let ((owner (map-get? token-owners token-id)))
+    (begin
+      (asserts! (is-some owner) (err u106))  ;; Token doesn't exist
+      (asserts! (is-eq (unwrap! owner (err u107)) tx-sender) (err u108))  ;; Only the owner can retire
+      (let ((metadata (unwrap! (map-get? token-metadata token-id) (err u109))))
+        (asserts! (not (get retired metadata)) (err u110))  ;; Already retired
+        (map-set token-metadata token-id (merge metadata {retired: true}))
+        (ok token-id)
+      )
+    )
+  )
+)
 
-        (ok token-id))))))
+(define-read-only (get-owner (token-id uint))
+  (ok (map-get? token-owners token-id))
+)
+
+(define-read-only (get-token-metadata (token-id uint))
+  (match (map-get? token-metadata token-id)
+    metadata (ok metadata)
+    (err u110)
+  )
+)


### PR DESCRIPTION
 Refactor Carbon Credit NFT Contract: Added retirement and transfer functionality

- Refactored the minting process to ensure proper input validation and metadata handling.
- Implemented a `retire-carbon-credit` function to allow owners to mark tokens as retired.
- Enhanced ownership transfer functionality with proper assertions and validation checks.
- Added metadata querying functions (`get-owner`, `get-token-metadata`) for better transparency and access to token details.
- Introduced optional error handling for token existence and validity during transfers and retirements.