### PR TITLE
Update CarbonListing.clar

### DIFF
--- a/contracts/CarbonListing.clar
+++ b/contracts/CarbonListing.clar
@@ -58,4 +58,13 @@
       )
     )
   )
+) 
+
+;;Remove a token from the listings map.
+(define-public (delist-token (token-id uint))
+  (begin
+    (asserts! (is-some (map-get? listings token-id)) (err u300)) ;; Make sure token is listed
+    (map-delete listings token-id)
+    (ok true)
+  )
 )


### PR DESCRIPTION
 The delist-token function was added to the .CarbonListing contract to:

Provide a public, callable method to remove a token from the listings map.

When the retirement contract calls (contract-call? .CarbonListing delist-token token-id), the .CarbonListing contract can safely delete the token listing internally.