### PR TITLE
Update CarbonCredits.clar

### DIFF
--- a/contracts/CarbonCredits.clar
+++ b/contracts/CarbonCredits.clar
@@ -59,3 +59,16 @@
   )
 )
 
+(define-public (update-metadata (token-id uint) (new-metadata {project: (string-utf8 50), location: (string-utf8 50), metric-ton: uint, retired: bool}))
+  (let ((owner (map-get? token-owners token-id)))
+    (begin
+      (asserts! (is-some owner) (err u106))
+      ;; Only the owner can update metadata
+      (asserts! (is-eq (unwrap! owner (err u107)) tx-sender) (err u108))
+      (asserts! (map-set token-metadata token-id new-metadata) (err u109))
+      (ok true)
+    )
+  )
+)
+
+


### PR DESCRIPTION
Add `update-metadata` public function to allow token owners to update NFT metadata

- Enables owners to modify metadata fields (project, location, metric-ton, retired)
- Adds ownership checks to ensure only the token owner can update metadata
- Supports use cases like retiring carbon credits by updating the `retired` flag
- Improves contract flexibility and security for metadata management