### PR TITLE
Update CarbonRetirement.clar

### DIFF
--- a/contracts/CarbonRetirement.clar
+++ b/contracts/CarbonRetirement.clar
@@ -1,17 +1,27 @@
 (define-public (retire-carbon-credit (token-id uint))
-  (let ((owner (contract-call? .CarbonCredits get-token-owner token-id))
-        (metadata (contract-call? .CarbonCredits get-token-metadata token-id)))
-    (begin
-      (asserts! (is-eq owner tx-sender) (err u400))
-      (asserts! (not (unwrap! metadata (err u401)).retired) (err u402))
+  (let (
+        ;; Call get-owner and unwrap the result
+        (owner-opt (unwrap! (contract-call? .CarbonCredits get-owner token-id) (err u400)))
+        (owner (unwrap! owner-opt (err u401)))
 
-      ;; Mark token as retired
-      (asserts! (contract-call? .CarbonCredits update-metadata token-id 
+        ;; Get metadata and unwrap
+        (metadata (unwrap! (contract-call? .CarbonCredits get-token-metadata token-id) (err u402)))
+       )
+    (begin
+      ;; Check if sender is owner
+      (asserts! (is-eq owner tx-sender) (err u403))
+
+      ;; Ensure not already retired
+      (asserts! (not (get retired metadata)) (err u404))
+
+      ;; Update metadata to mark as retired
+      (unwrap! (contract-call? .CarbonCredits update-metadata token-id 
         (merge 
-          (unwrap! metadata (err u403))
-          {retired: true})) (err u404))
+          metadata
+          {retired: true})) (err u405))
 
       ;; Remove from sale if listed
-      (map-delete .CarbonListing listings token-id)
+      
+      (unwrap! (contract-call? .CarbonListing delist-token token-id) (err u500))
 
-      (ok token-id)))))
+      (ok token-id))))


### PR DESCRIPTION
Add retire-carbon-credit function to mark tokens as retired and delist them

- Verifies that the caller owns the token
- Checks the token is not already retired
- Updates token metadata to set `retired: true`
- Calls external contract to remove token from sale listings
- Ensures atomic operation with error handling for all steps